### PR TITLE
Guard intrin.h against clang

### DIFF
--- a/MathExtras.h
+++ b/MathExtras.h
@@ -19,7 +19,7 @@
 
 #if defined(_WIN32_WCE) && (_WIN32_WCE < 0x800)
 #include "windowsce/intrin.h"
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
 #endif
 


### PR DESCRIPTION
If cross-compiling for MSVC using clang, we cannot use `intrin.h`, as it doesn't actually define the intrinsics, it just forward declares them, which is insufficient for clang.